### PR TITLE
Migrate automation to blueprint

### DIFF
--- a/MQTTCarPresence.yaml
+++ b/MQTTCarPresence.yaml
@@ -1,29 +1,51 @@
-# car sensor is connected and the garage door is closed
-- alias: CarPresence_ON
-  trigger:
-    platform: state
-    entity_id: binary_sensor.CarPresence
+blueprint:
+  name: MQTTCarPresence
+  description: Open garage door when car connects to Wi-Fi
+  domain: automation
+  input:
+    garage_door:
+      name: Garage Door Cover
+      description: This cover is the Garage Door
+      selector:
+        entity:
+          domain: cover
+    car_presence:
+      name: Car Presence Sensor
+      description: "This sensor is the car's connection to the MQTT broker"
+      selector:
+        entity:
+          domain: binary_sensor
+mode: single
+trigger:
+  - platform: state
+    entity_id: !input car_presence
     to: 'on'
-  condition:
-  - condition: state
-    entity_id: 'cover.garage_door'
-    state: 'closed'
-  action:
-  - service: cover.open_cover
-    entity_id: 'cover.garage_door'
-
-# car sensor is disconnected for one minute and the garage door is open
-- alias: CarPresence_OFF
-  trigger:
-    platform: state
-    entity_id: binary_sensor.CarPresence
+  - platform: state
+    entity_id: !input car_presence
     to: 'off'
     for:
       minutes: 1
-  condition:
-  - condition: state
-    entity_id: 'cover.garage_door'
-    state: 'open'
-  action:
-  - service: cover.close_cover
-    entity_id: 'cover.garage_door'
+condition: []
+action:
+  - choose:
+      - conditions:
+          - condition: state
+            entity_id: !input car_presence
+            state: 'on'
+          - condition: state
+            entity_id: !input garage_door
+            state: closed
+        sequence:
+          - service: cover.open_cover
+            entity_id: !input garage_door
+      - conditions:
+          - condition: state
+            entity_id: !input car_presence
+            state: 'off'
+          - condition: state
+            entity_id: !input garage_door
+            state: open
+        sequence:
+          - service: cover.close_cover
+            entity_id: !input garage_door
+    default: []


### PR DESCRIPTION
I made this automation into a blueprint, which is a new form of sharing automations. (introduced in 2020.12/1.0)  [https://www.home-assistant.io/blog/2020/12/13/release-202012/#blueprints](https://www.home-assistant.io/blog/2020/12/13/release-202012/#blueprints)

You can test the blueprint by importing it with this link: [https://raw.githubusercontent.com/reesericci/MQTTCarPresence/patch-1/MQTTCarPresence.yaml](https://raw.githubusercontent.com/reesericci/MQTTCarPresence/patch-1/MQTTCarPresence.yaml
)
If the blueprints panel is not available in settings, then you need to update to the latest version of Home Assistant.

(I'm using the github raw link pointing to my forked repo, if merged you will have to change the import link to link to the main repository's copy. (raw link oc) )