### PR TITLE
Add source URL to blueprints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "*.yaml": "home-assistant"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/MQTTCarPresence.yaml
+++ b/MQTTCarPresence.yaml
@@ -1,6 +1,7 @@
 blueprint:
   name: MQTTCarPresence
   description: Open garage door when car connects to Wi-Fi
+  source_url: https://github.com/aderusha/MQTTCarPresence/blob/master/MQTTCarPresence.yaml
   domain: automation
   input:
     garage_door:

--- a/MQTT_Tasmota_CarPresence.yaml
+++ b/MQTT_Tasmota_CarPresence.yaml
@@ -1,6 +1,7 @@
 blueprint:
   name: MQTT_Tasmota_CarPresence
   description: Open garage door when car connects to Wi-Fi
+  source_url: https://github.com/aderusha/MQTTCarPresence/blob/master/MQTT_Tasmota_CarPresence.yaml
   domain: automation
   input:
     garage_door:


### PR DESCRIPTION
Added source_url to both blueprints pointing to within the same repo.
Then they will be able to navigate back to the repo if there are issues.

My GIST and bp exchange files have been removed, 
🎯  the Tasmota bp only lives here now. (as it should be)