### PR TITLE
Set MQTT buffer size from API

### DIFF
--- a/MQTTCarPresence/MQTTCarPresence.ino
+++ b/MQTTCarPresence/MQTTCarPresence.ino
@@ -21,8 +21,6 @@ const String mqttDiscoSignalConfigTopic = mqttDiscoveryPrefix + "/sensor/" + mqt
 const String mqttDiscoUptimeStateTopic = mqttDiscoveryPrefix + "/sensor/" + mqttNode + "-uptime/state";
 const String mqttDiscoUptimeConfigTopic = mqttDiscoveryPrefix + "/sensor/" + mqttNode + "-uptime/config";
 
-// The strings below will spill over the PubSubClient_MAX_PACKET_SIZE 128
-// You'll need to manually set MQTT_MAX_PACKET_SIZE in PubSubClient.h to 512
 const String mqttDiscoBinaryConfigPayload = "{\"name\": \"" + mqttNode + "\", \"device_class\": \"connectivity\", \"state_topic\": \"" + mqttDiscoBinaryStateTopic + "\"}";
 const String mqttDiscoSignalConfigPayload = "{\"name\": \"" + mqttNode + "-signal\", \"state_topic\": \"" + mqttDiscoSignalStateTopic + "\", \"unit_of_measurement\": \"dBm\", \"value_template\": \"{{ value }}\"}";
 const String mqttDiscoUptimeConfigPayload = "{\"name\": \"" + mqttNode + "-uptime\", \"state_topic\": \"" + mqttDiscoUptimeStateTopic + "\", \"unit_of_measurement\": \"msec\", \"value_template\": \"{{ value }}\"}";
@@ -60,6 +58,10 @@ void setup()
   // Create server and assign callbacks for MQTT
   mqttClient.setServer(mqttServer, 1883);
   mqttClient.setCallback(mqtt_callback);
+
+// The string payloads spill over the default MAX_PACKET_SIZE 128.
+  mqttClient.setBufferSize(512);
+
   mqttConnect();
 
   // Start up OTA

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ This project utilizes a [WeMos D1 mini Pro](https://wiki.wemos.cc/products:d1:d1
 
 The first order of business will be to setup the Arduino IDE to flash the provided Arduino sketch to the ESP8266.  [Download the IDE for your platform](https://www.arduino.cc/en/Main/Software) and [follow these instructions to add support for the ESP8266 platform](https://github.com/esp8266/Arduino#installing-with-boards-manager).
 
-Next you will need to add the PubSubClient library for MQTT.  [Follow this guide for the general process](https://www.arduino.cc/en/Guide/Libraries) and add the 'PubSubClient' from the Library Manager.  Once that is installed you will need to edit the `PubSubClient.h` file and change the line `#define MQTT_MAX_PACKET_SIZE 128` to `#define MQTT_MAX_PACKET_SIZE 512`.  You can find the installed library under the path shown in `File > Preferences > Sketchbook location`.
+Next you will need to add the PubSubClient library for MQTT.  [Follow this guide for the general process](https://www.arduino.cc/en/Guide/Libraries) and add the 'PubSubClient' from the Library Manager.
 
 [At the top of the Arduino sketch are several fields you must modify to fit your environment](https://github.com/aderusha/MQTTCarPresence/blob/master/MQTTCarPresence/MQTTCarPresence.ino#L3-L10) (WiFi details, MQTT broker IP, node name, etc).  Once those fields have been set you can upload to your microcontroller and monitor sensor status in Home Assistant.
 


### PR DESCRIPTION
There is no longer a need to edit to library. The `setBufferSize` function was added in [v2.8](https://github.com/knolleary/pubsubclient/releases/tag/v2.8).