### PR TITLE
Update Blueprint for HA 2023.3.0 Update

### DIFF
--- a/MQTTCarPresence.yaml
+++ b/MQTTCarPresence.yaml
@@ -1,8 +1,11 @@
 blueprint:
   name: MQTTCarPresence
+  author: aderusha (Luma)
   description: Open garage door when car connects to Wi-Fi
   source_url: https://github.com/aderusha/MQTTCarPresence/blob/master/MQTTCarPresence.yaml
   domain: automation
+  homeassistant:
+    min_version: 2023.3.0
   input:
     garage_door:
       name: Garage Door Cover

--- a/MQTTCarPresence.yaml
+++ b/MQTTCarPresence.yaml
@@ -12,13 +12,15 @@ blueprint:
       description: This cover is the Garage Door
       selector:
         entity:
-          domain: cover
+          filter:
+            - domain: cover
     car_presence:
       name: Car Presence Sensor
       description: "This sensor is the car's connection to the MQTT broker"
       selector:
         entity:
-          domain: binary_sensor
+          filter:
+            - domain: binary_sensor
 mode: single
 trigger:
   - platform: state

--- a/MQTTCarPresence.yaml
+++ b/MQTTCarPresence.yaml
@@ -5,7 +5,7 @@ blueprint:
   source_url: https://github.com/aderusha/MQTTCarPresence/blob/master/MQTTCarPresence.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.3.0
+    min_version: 2023.6.2
   input:
     garage_door:
       name: Garage Door Cover

--- a/MQTT_Tasmota_CarPresence.yaml
+++ b/MQTT_Tasmota_CarPresence.yaml
@@ -12,13 +12,15 @@ blueprint:
       description: This cover is the Garage Door
       selector:
         entity:
-          domain: cover
+          filter:
+            - domain: cover
     car_presence:
       name: Car Presence
       description: "This switch is the car's connection to the MQTT broker"
       selector:
         entity:
-          domain: switch
+          filter:
+            - domain: switch
 mode: single
 trigger:
   - platform: state

--- a/MQTT_Tasmota_CarPresence.yaml
+++ b/MQTT_Tasmota_CarPresence.yaml
@@ -1,8 +1,11 @@
 blueprint:
   name: MQTT_Tasmota_CarPresence
+  author: SirGoodenough
   description: Open garage door when car connects to Wi-Fi
   source_url: https://github.com/aderusha/MQTTCarPresence/blob/master/MQTT_Tasmota_CarPresence.yaml
   domain: automation
+  homeassistant:
+    min_version: 2023.3.0
   input:
     garage_door:
       name: Garage Door

--- a/MQTT_Tasmota_CarPresence.yaml
+++ b/MQTT_Tasmota_CarPresence.yaml
@@ -5,7 +5,7 @@ blueprint:
   source_url: https://github.com/aderusha/MQTTCarPresence/blob/master/MQTT_Tasmota_CarPresence.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.3.0
+    min_version: 2023.6.2
   input:
     garage_door:
       name: Garage Door


### PR DESCRIPTION
Not required changes, but ones recommended by the HA team.

From HA 2023.3 release podcast:
https://www.youtube.com/live/3UaLAhG9Brc?feature=share&t=3150

Docs Link:
https://www.home-assistant.io/docs/blueprint/schema/#author